### PR TITLE
Respond.js not in precompile assets list

### DIFF
--- a/lib/respond-js-rails/engine.rb
+++ b/lib/respond-js-rails/engine.rb
@@ -1,7 +1,7 @@
 module RespondJsRails
   class Engine < ::Rails::Engine
     initializer "respond-js-rails.assets.precompile" do |app|
-      app.config.assets.precompile << %w(respond.js)
+      app.config.assets.precompile += %w(respond.js)
     end
   end
 end


### PR DESCRIPTION
Since Rails 4 can you no longer use `<<` but needs to use `+=` when you add assets to the precompile list. Otherwise will the asset be added as a nested array.

This pull request fixes that.
